### PR TITLE
LLVM code generation for simple loops

### DIFF
--- a/torch/csrc/jit/compiler/include/llvm_codegen.h
+++ b/torch/csrc/jit/compiler/include/llvm_codegen.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include "torch/csrc/jit/compiler/include/ir_visitor.h"
+#include "torch/csrc/jit/compiler/include/ir.h"
 #include "torch/csrc/jit/compiler/include/llvm_jit.h"
 
 #include <llvm/IR/IRBuilder.h>
+#include <unordered_map>
+#include <vector>
 
 namespace torch {
 namespace jit {
@@ -19,16 +22,31 @@ class LLVMCodeGen : public IRVisitor {
   llvm::BasicBlock* bb_;
   llvm::Value* value_;
   llvm::Type* int32Ty_;
+  std::unordered_map<const BaseExprNode *, int> varToArg_;
+  std::unordered_map<const Variable *, llvm::Value *> varToVal_;
 
  public:
+  explicit LLVMCodeGen(const std::vector<Buffer *> &args);
   LLVMCodeGen();
+
   void visit(const Add* v) override;
   void visit(const Sub* v) override;
   void visit(const Mul* v) override;
   void visit(const Div* v) override;
   void visit(const IntImm* v) override;
   void visit(const FloatImm* v) override;
+  void visit(const Cast* v) override;
+  void visit(const Variable* v) override;
+  void visit(const Let* v) override;
+  void visit(const Ramp* v) override;
+  void visit(const Load* v) override;
+  void visit(const For* v) override;
+  void visit(const Block* v) override;
+  void visit(const Store* v) override;
+  void visit(const Broadcast* v) override;
+
   int value();
+  int value(std::vector<void *> &args);
 };
 
 } // namespace compiler

--- a/torch/csrc/jit/compiler/include/logging.h
+++ b/torch/csrc/jit/compiler/include/logging.h
@@ -15,6 +15,12 @@ const int ERROR = 2;
 const int WARNING = 1;
 const int INFO = 0;
 
+__attribute__((noreturn))
+inline void assert_unreachable(const char *msg) {
+  std::cerr << msg << "\n";
+  std::abort();
+}
+
 class MessageLogger {
  public:
   static std::string SeverityToString(int severity) {
@@ -28,6 +34,7 @@ class MessageLogger {
       case INFO:
         return "INFO";
     }
+    assert_unreachable("No such severity level");
   }
 
   MessageLogger(const char* file, int line, int severity)

--- a/torch/csrc/jit/compiler/include/types.h
+++ b/torch/csrc/jit/compiler/include/types.h
@@ -73,6 +73,7 @@ inline Dtype BinaryOpDtype(Dtype op1_dtype, Dtype op2_dtype) {
     return op1_dtype;
   }
   LOG(FATAL) << "Invalid dtypes: " << op1_dtype << ", " << op2_dtype;
+  assert_unreachable("Invalid dtypes");
 }
 
 } // namespace compiler

--- a/torch/csrc/jit/compiler/src/llvm_codegen.cc
+++ b/torch/csrc/jit/compiler/src/llvm_codegen.cc
@@ -1,13 +1,18 @@
 #include "torch/csrc/jit/compiler/include/llvm_codegen.h"
 #include "torch/csrc/jit/compiler/include/ir.h"
+#include "torch/csrc/jit/compiler/include/types.h"
 
+#include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/TargetSelect.h>
+#include <llvm/Target/TargetMachine.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <memory>
 
 using namespace torch::jit::compiler;
 
-LLVMCodeGen::LLVMCodeGen() : irb_(context_) {
+LLVMCodeGen::LLVMCodeGen(const std::vector<Buffer *> &args) : irb_(context_) {
   llvm::InitializeNativeTarget();
   llvm::InitializeNativeTargetAsmPrinter();
   llvm::InitializeNativeTargetAsmParser();
@@ -17,15 +22,45 @@ LLVMCodeGen::LLVMCodeGen() : irb_(context_) {
   module_->setTargetTriple(
       jit_->getTargetMachine().getTargetTriple().normalize());
 
-  // Emit prototype.
   int32Ty_ = llvm::Type::getInt32Ty(context_);
 
-  llvm::FunctionType* fntype = llvm::FunctionType::get(int32Ty_, {}, false);
+  // Emit prototype.
+  std::vector<llvm::Type *> params;
+  for (int i = 0; i < args.size(); i++) {
+    params.push_back(llvm::Type::getInt32PtrTy(context_));
+    varToArg_[args[i]->data().node()] = i;
+  }
+  llvm::FunctionType* fntype = llvm::FunctionType::get(int32Ty_, params, false);
   fn_ = llvm::Function::Create(
-      fntype, llvm::Function::ExternalLinkage, "pytorch", module_.get());
+    fntype, llvm::Function::PrivateLinkage, "pytorch", module_.get());
+  for (int i = 0; i < args.size(); i++) {
+    fn_->addParamAttr(i, llvm::Attribute::NoAlias);
+  }
+
+  // Emit wrapper to unpack argument vector.
+  auto i32pp = int32Ty_->getPointerTo()->getPointerTo();
+  auto wrapper = llvm::Function::Create(
+    llvm::FunctionType::get(int32Ty_, {i32pp}, false),
+    llvm::Function::ExternalLinkage, "wrapper", module_.get());
+  auto wrapBB = llvm::BasicBlock::Create(context_, "wrapBB", wrapper);
+  irb_.SetInsertPoint(wrapBB);
+  llvm::SmallVector<llvm::Value *, 6> wrappedArgs;
+  for (size_t i = 0 ; i < args.size(); i++) {
+    auto argp = irb_.CreateGEP(
+      wrapper->arg_begin(),
+      llvm::Constant::getIntegerValue(int32Ty_, llvm::APInt(32, i)));
+    auto arg = irb_.CreateLoad(argp);
+    wrappedArgs.push_back(arg);
+  }
+  auto cc = irb_.CreateCall(fn_, wrappedArgs);
+  irb_.CreateRet(cc);
+
+  // Set insert point to the real function.
   bb_ = llvm::BasicBlock::Create(context_, "entry", fn_);
   irb_.SetInsertPoint(bb_);
 }
+
+LLVMCodeGen::LLVMCodeGen() : LLVMCodeGen({}) {}
 
 void LLVMCodeGen::visit(const Add* v) {
   v->lhs().accept(this);
@@ -68,16 +103,137 @@ void LLVMCodeGen::visit(const FloatImm* v) {
   assert(false && "Integer only now sorry");
 }
 
+void LLVMCodeGen::visit(const Cast* v) {}
+
+void LLVMCodeGen::visit(const Variable* v) {
+  if (varToArg_.count(v)) {
+    auto idx = varToArg_.at(v);
+    auto arg = fn_->arg_begin() + idx;
+    value_ = arg;
+  } else if (varToVal_.count(v)) {
+    value_ = varToVal_.at(v);
+  }
+}
+
+void LLVMCodeGen::visit(const Let* v) {}
+void LLVMCodeGen::visit(const Ramp* v) {}
+
+void LLVMCodeGen::visit(const Load* v) {
+  v->base_handle().accept(this);
+  auto base = this->value_;
+  v->index().accept(this);
+  auto idx = this->value_;
+  auto addr = irb_.CreateGEP(base, idx);
+  value_ = irb_.CreateLoad(addr);
+}
+
+void LLVMCodeGen::visit(const For* v) {
+  // Create "start" value.
+  v->start().accept(this);
+  auto start = this->value_;
+
+  // Create loop preheader and body.
+  auto preheader = irb_.GetInsertBlock();
+  auto loop = llvm::BasicBlock::Create(context_, "loop", fn_);
+  irb_.CreateBr(loop);
+  irb_.SetInsertPoint(loop);
+
+  // Set up phi node for index variable.
+  auto idx = irb_.CreatePHI(int32Ty_, 2);
+  idx->addIncoming(start, preheader);
+  varToVal_.emplace(v->var().node(), idx);
+
+  // Codegen the body.
+  v->body().accept(this);
+
+  // Create the stop condition. and "after" block.
+  auto inc = irb_.CreateAdd(idx,  llvm::Constant::getIntegerValue(int32Ty_, llvm::APInt(32, 1)));
+  v->stop().accept(this);
+  auto stop = this->value_;
+  auto cond = irb_.CreateICmpSLT(inc, stop);
+
+  // Branch back to top of loop and finish phi for index variable.
+  auto end_loop = irb_.GetInsertBlock();
+  auto after = llvm::BasicBlock::Create(context_, "after", fn_);
+  irb_.CreateCondBr(cond, loop, after);
+  irb_.SetInsertPoint(after);
+  idx->addIncoming(inc, end_loop);
+  value_ = llvm::Constant::getIntegerValue(int32Ty_, llvm::APInt(32, 0));
+}
+
+void LLVMCodeGen::visit(const Block* v) {
+  for (int i = 0; i < v->nstmts(); i++) {
+    v->stmt(i).accept(this);
+  }
+}
+
+void LLVMCodeGen::visit(const Store* v) {
+  v->base_handle().accept(this);
+  auto base = this->value_;
+  v->index().accept(this);
+  auto idx = this->value_;
+  v->value().accept(this);
+  auto val = this->value_;
+  auto addr = irb_.CreateGEP(base, idx);
+  irb_.CreateStore(val, addr);
+  value_ = llvm::Constant::getIntegerValue(int32Ty_, llvm::APInt(32, 0));
+}
+
+void LLVMCodeGen::visit(const Broadcast* v) {}
+
+void optimize(llvm::TargetMachine &TM, llvm::Module &M) {
+  llvm::legacy::FunctionPassManager FPM(&M);
+  llvm::legacy::PassManager PM;
+
+  // Add internal analysis passes from the target machine.
+  PM.add(llvm::createTargetTransformInfoWrapperPass(TM.getTargetIRAnalysis()));
+  FPM.add(llvm::createTargetTransformInfoWrapperPass(TM.getTargetIRAnalysis()));
+
+  llvm::PassManagerBuilder PMB;
+  PMB.OptLevel = 3;
+  PMB.LoopVectorize = true;
+  PMB.SLPVectorize = true;
+  TM.adjustPassManager(PMB);
+
+  PMB.populateFunctionPassManager(FPM);
+  PMB.populateModulePassManager(PM);
+  FPM.doInitialization();
+  PM.run(M);
+  for (auto &FF : M) {
+    FPM.run(FF);
+  }
+  FPM.doFinalization();
+  PM.run(M);
+}
+
 int LLVMCodeGen::value() {
+  std::vector<void *> args;
+  return value(args);
+}
+
+int LLVMCodeGen::value(std::vector<void *> &args) {
   irb_.CreateRet(value_);
   assert(!llvm::verifyFunction(*fn_, &llvm::outs()));
+  optimize(jit_->getTargetMachine(), *module_);
+
+#if DEBUG_PRINT
+  llvm::errs() << *module_;
+  llvm::SmallVector<char, 0> asmBuffer;
+  llvm::raw_svector_ostream asmStream(asmBuffer);
+  llvm::legacy::PassManager PM;
+  jit_->getTargetMachine().addPassesToEmitFile(
+    PM, asmStream, nullptr,
+    llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
+  PM.run(*module_);
+  llvm::errs() << asmStream.str();
+#endif
 
   auto key = jit_->addModule(std::move(module_));
-  auto sym = jit_->findSymbol("pytorch");
+  auto sym = jit_->findSymbol("wrapper");
   auto addr = sym.getAddress();
   assert(addr);
-  int (*fp)() = (int (*)())addr.get();
-  int rv = fp();
+  int (*fp)(void **) = (int (*)(void **))addr.get();
+  int rv = fp(args.data());
   jit_->removeModule(key);
   return rv;
 }

--- a/torch/csrc/jit/compiler/tests/llvm_test.cc
+++ b/torch/csrc/jit/compiler/tests/llvm_test.cc
@@ -5,14 +5,21 @@
 
 using namespace torch::jit::compiler;
 
-TEST(ExprTest, IntImmTest) {
+template<typename T>
+static void assertAllEqual(const std::vector<T> &vec, const T &val) {
+  for (auto const &elt : vec) {
+    ASSERT_EQ(elt, val);
+  }
+}
+
+TEST(LLVMTest, IntImmTest) {
   auto a = IntImm::make(2);
   LLVMCodeGen cg;
   a.accept(&cg);
   EXPECT_EQ(cg.value(), 2);
 }
 
-TEST(ExprTest, IntAddTest) {
+TEST(LLVMTest, IntAddTest) {
   auto a = IntImm::make(2);
   auto b = IntImm::make(3);
   auto c = Add::make(a, b);
@@ -21,7 +28,7 @@ TEST(ExprTest, IntAddTest) {
   EXPECT_EQ(cg.value(), 5);
 }
 
-TEST(ExprTest, IntSubTest) {
+TEST(LLVMTest, IntSubTest) {
   auto a = IntImm::make(2);
   auto b = IntImm::make(3);
   auto c = Sub::make(a, b);
@@ -30,7 +37,7 @@ TEST(ExprTest, IntSubTest) {
   EXPECT_EQ(cg.value(), -1);
 }
 
-TEST(ExprTest, IntMulTest) {
+TEST(LLVMTest, IntMulTest) {
   auto a = IntImm::make(2);
   auto b = IntImm::make(3);
   auto c = Mul::make(a, b);
@@ -39,11 +46,120 @@ TEST(ExprTest, IntMulTest) {
   EXPECT_EQ(cg.value(), 6);
 }
 
-TEST(ExprTest, IntDivTest) {
+TEST(LLVMTest, IntDivTest) {
   auto a = IntImm::make(6);
   auto b = IntImm::make(3);
   auto c = Div::make(a, b);
   LLVMCodeGen cg;
   c.accept(&cg);
   EXPECT_EQ(cg.value(), 2);
+}
+
+TEST(LLVMTest, BufferTest) {
+  Buffer a(Var("A", kHandle), kFloat32, {32});
+  LLVMCodeGen cg({&a});
+  std::vector<int32_t> v(5);
+  std::vector<void *> args({v.data()});
+  auto rv = IntImm::make(0);
+  rv.accept(&cg);
+  EXPECT_EQ(cg.value(args), 0);
+}
+
+TEST(LLVMTest, LoadStoreTest) {
+  Buffer a(Var("A", kHandle), kInt32, {1});
+  Buffer b(Var("B", kHandle), kInt32, {1});
+  std::vector<int32_t> a_buffer = {42};
+  std::vector<int32_t> b_buffer = {-11};
+
+  LLVMCodeGen cg({&a, &b});
+  auto store = Store::make(
+    b,
+    IntImm::make(0),
+    Load::make(a, IntImm::make(0), IntImm::make(1)),
+    IntImm::make(1));
+  store.accept(&cg);
+  std::vector<void *> args({a_buffer.data(), b_buffer.data()});
+  EXPECT_EQ(cg.value(args), 0);
+  EXPECT_EQ(a_buffer[0], 42);
+  EXPECT_EQ(b_buffer[0], 42);
+}
+
+TEST(LLVMTest, MemcpyTest) {
+  constexpr int N = 32;
+  Buffer a(Var("A", kHandle), kInt32, {N});
+  Buffer b(Var("B", kHandle), kInt32, {N});
+  std::vector<int32_t> a_buffer(N, 42);
+  std::vector<int32_t> b_buffer(N, 0);
+
+  auto mask = IntImm::make(1);
+  Var i("i", kInt32);
+  auto memcpy_expr = For::make(
+    i, 0, N,
+    Store::make(b, i, Load::make(a, i, mask), mask));
+
+  LLVMCodeGen cg({&a, &b});
+  memcpy_expr.accept(&cg);
+
+  std::vector<void *> args({a_buffer.data(), b_buffer.data()});
+  ASSERT_EQ(cg.value(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  assertAllEqual(a_buffer, 42);
+  assertAllEqual(b_buffer, 42);
+}
+
+TEST(LLVMTest, BzeroTest) {
+  constexpr int N = 32;
+  Buffer b(Var("B", kHandle), kInt32, {N});
+  std::vector<int32_t> b_buffer(N, 11);
+
+  auto mask = IntImm::make(1);
+  Var i("i", kInt32);
+  auto memcpy_expr = For::make(
+    i, 0, N,
+    Store::make(b, i, IntImm::make(0), mask));
+
+  LLVMCodeGen cg({&b});
+  memcpy_expr.accept(&cg);
+
+  std::vector<void *> args({b_buffer.data()});
+  ASSERT_EQ(cg.value(args), 0);
+
+  ASSERT_EQ(b_buffer.size(), N);
+  assertAllEqual(b_buffer, 0);
+}
+
+TEST(LLVMTest, ElemwiseAdd) {
+  constexpr int N = 1024;
+  Buffer a(Var("A", kHandle), kInt32, {N});
+  Buffer b(Var("B", kHandle), kInt32, {N});
+  Buffer c(Var("C", kHandle), kInt32, {N});
+  std::vector<int32_t> a_buffer(N, 41);
+  std::vector<int32_t> b_buffer(N, 1);
+  std::vector<int32_t> c_buffer(N, 1);
+
+  auto mask = IntImm::make(1);
+  Var i("i", kInt32);
+  auto memcpy_expr = For::make(
+    i, 0, N,
+    Store::make(
+      c, i,
+      Add::make(
+        Load::make(a, i, mask),
+        Load::make(b, i, mask)),
+      mask));
+
+  LLVMCodeGen cg({&a, &b, &c});
+  memcpy_expr.accept(&cg);
+
+  std::vector<void *> args({a_buffer.data(), b_buffer.data(), c_buffer.data()});
+  ASSERT_EQ(cg.value(args), 0);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+  ASSERT_EQ(c_buffer.size(), N);
+  assertAllEqual(a_buffer, 41);
+  assertAllEqual(b_buffer, 1);
+  assertAllEqual(c_buffer, 42);
 }


### PR DESCRIPTION
If you turn on the DEBUG_PRINT macro, check out the unrolled/vectorized goodness for the ElemwiseAdd test:
```
        .p2align        4, 0x90
l_pytorch:
        xorl    %eax, %eax
        .p2align        4, 0x90
LBB0_1:
        vmovdqu (%rsi,%rax,4), %ymm0
        vmovdqu 32(%rsi,%rax,4), %ymm1
        vmovdqu 64(%rsi,%rax,4), %ymm2
        vmovdqu 96(%rsi,%rax,4), %ymm3
        vpaddd  (%rdi,%rax,4), %ymm0, %ymm0
        vpaddd  32(%rdi,%rax,4), %ymm1, %ymm1
        vpaddd  64(%rdi,%rax,4), %ymm2, %ymm2
        vpaddd  96(%rdi,%rax,4), %ymm3, %ymm3
        vmovdqu %ymm0, (%rdx,%rax,4)
        vmovdqu %ymm1, 32(%rdx,%rax,4)
        vmovdqu %ymm2, 64(%rdx,%rax,4)
        vmovdqu %ymm3, 96(%rdx,%rax,4)
        vmovdqu 128(%rsi,%rax,4), %ymm0
        vmovdqu 160(%rsi,%rax,4), %ymm1
        vmovdqu 192(%rsi,%rax,4), %ymm2
        vmovdqu 224(%rsi,%rax,4), %ymm3
        vpaddd  128(%rdi,%rax,4), %ymm0, %ymm0
        vpaddd  160(%rdi,%rax,4), %ymm1, %ymm1
        vpaddd  192(%rdi,%rax,4), %ymm2, %ymm2
        vpaddd  224(%rdi,%rax,4), %ymm3, %ymm3
        vmovdqu %ymm0, 128(%rdx,%rax,4)
        vmovdqu %ymm1, 160(%rdx,%rax,4)
        vmovdqu %ymm2, 192(%rdx,%rax,4)
        vmovdqu %ymm3, 224(%rdx,%rax,4)
        addq    $64, %rax
        cmpq    $1024, %rax
        jne     LBB0_1
        vzeroupper
        retq
```